### PR TITLE
Improve visualizer websocket resilience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # deps
 # Node.js dependencies
 node_modules
+sdk/typescript/v8-compile-cache-*
 .pnpm-store
 .pnpm-debug.log
 

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1077,6 +1077,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-test",
+ "tokio-tungstenite",
  "tokio-util",
  "toml",
  "toml_edit",
@@ -1084,6 +1085,7 @@ dependencies = [
  "tracing-test",
  "tree-sitter",
  "tree-sitter-bash",
+ "url",
  "uuid",
  "walkdir",
  "which",
@@ -1770,6 +1772,12 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "dbus"
@@ -6011,6 +6019,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6319,6 +6339,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6411,6 +6449,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -61,12 +61,14 @@ tokio = { workspace = true, features = [
     "rt-multi-thread",
     "signal",
 ] }
+tokio-tungstenite = "0.24"
 tokio-util = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 tree-sitter = { workspace = true }
 tree-sitter-bash = { workspace = true }
+url = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
 which = { workspace = true }
 wildmatch = { workspace = true }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -27,6 +27,7 @@ use futures::prelude::*;
 use mcp_types::CallToolResult;
 use serde_json;
 use serde_json::Value;
+use serde_json::json;
 use tokio::sync::Mutex;
 use tokio::sync::oneshot;
 use tracing::debug;
@@ -61,6 +62,7 @@ use crate::openai_model_info::get_model_info;
 use crate::openai_tools::ToolsConfig;
 use crate::openai_tools::ToolsConfigParams;
 use crate::parse_command::parse_command;
+use crate::project_doc::discover_project_doc_paths;
 use crate::project_doc::get_user_instructions;
 use crate::protocol::AgentMessageDeltaEvent;
 use crate::protocol::AgentReasoningDeltaEvent;
@@ -108,6 +110,8 @@ use crate::unified_exec::UnifiedExecSessionManager;
 use crate::user_instructions::UserInstructions;
 use crate::user_notification::UserNotification;
 use crate::util::backoff;
+use crate::visualizer::AgentVisualizer;
+use crate::visualizer::SessionVisualizer;
 use codex_otel::otel_event_manager::OtelEventManager;
 use codex_protocol::config_types::ReasoningEffort as ReasoningEffortConfig;
 use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
@@ -151,8 +155,58 @@ impl Codex {
     ) -> CodexResult<CodexSpawnOk> {
         let (tx_sub, rx_sub) = async_channel::bounded(SUBMISSION_CHANNEL_CAPACITY);
         let (tx_event, rx_event) = async_channel::unbounded();
+        let visualizer = AgentVisualizer::from_env();
 
+        // Visualization hook: this is where AGENTS.md guidance (plus any
+        // configured overrides) is loaded into memory before the session
+        // starts. Emit a "memory bootstrap" event that captures the resolved
+        // `user_instructions` string, whether it originated from
+        // `config.user_instructions`, project docs, or defaults, and the
+        // effective `config.base_instructions`. Also include
+        // `config.project_doc_max_bytes`/`config.cwd` so the UI can explain how
+        // the instruction block was assembled.
+        let project_doc_paths = match discover_project_doc_paths(&config) {
+            Ok(paths) => paths,
+            Err(err) => {
+                error!("failed to discover project docs for visualization: {err:#}");
+                Vec::new()
+            }
+        };
+        let project_doc_path_strings: Vec<String> = project_doc_paths
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
         let user_instructions = get_user_instructions(&config).await;
+        let instructions_source = match (
+            config.user_instructions.is_some(),
+            !project_doc_paths.is_empty(),
+        ) {
+            (true, true) => "user+project_doc",
+            (true, false) => "user",
+            (false, true) => "project_doc",
+            (false, false) => "none",
+        };
+
+        visualizer
+            .emit(
+                None,
+                "memory_bootstrap",
+                json!({
+                    "instructionsSource": instructions_source,
+                    "userInstructions": user_instructions,
+                    "projectDocPaths": project_doc_path_strings,
+                    "projectDocMaxBytes": config.project_doc_max_bytes,
+                    "baseInstructions": config.base_instructions,
+                    "cwd": config.cwd.display().to_string(),
+                }),
+                Some(json!({
+                    "model": config.model,
+                    "provider": config.model_provider,
+                    "approvalPolicy": config.approval_policy,
+                    "sandboxPolicy": config.sandbox_policy,
+                })),
+            )
+            .await;
 
         let config = Arc::new(config);
 
@@ -177,6 +231,7 @@ impl Codex {
             tx_event.clone(),
             conversation_history,
             session_source,
+            visualizer.clone(),
         )
         .await
         .map_err(|e| {
@@ -186,7 +241,33 @@ impl Codex {
         let conversation_id = session.conversation_id;
 
         // This task will run until Op::Shutdown is received.
-        tokio::spawn(submission_loop(session, turn_context, config, rx_sub));
+        // Visualization hook: the spawned submission_loop task is the core
+        // agent event loop. Emit a "session loop started" event containing the
+        // generated `conversation_id`, selected `config.model`, provider id,
+        // and sandbox/approval policies so downstream instrumentation can anchor
+        // turn/task phases to a single async task identifier.
+        tokio::spawn(submission_loop(
+            session.clone(),
+            turn_context,
+            config.clone(),
+            rx_sub,
+        ));
+
+        let session_loop_state = session.visualization_state_snapshot().await;
+        session
+            .visualizer
+            .emit(
+                "session_loop_started",
+                json!({
+                    "model": config.model.clone(),
+                    "provider": config.model_provider.clone(),
+                    "sandboxPolicy": config.sandbox_policy.clone(),
+                    "approvalPolicy": config.approval_policy,
+                    "sessionSource": session_source,
+                }),
+                Some(session_loop_state),
+            )
+            .await;
         let codex = Codex {
             next_id: AtomicU64::new(0),
             tx_sub,
@@ -242,6 +323,7 @@ pub(crate) struct Session {
     pub(crate) active_turn: Mutex<Option<ActiveTurn>>,
     pub(crate) services: SessionServices,
     next_internal_sub_id: AtomicU64,
+    visualizer: SessionVisualizer,
 }
 
 /// The context needed for a single turn of the conversation.
@@ -312,6 +394,7 @@ impl Session {
         tx_event: Sender<Event>,
         initial_history: InitialHistory,
         session_source: SessionSource,
+        visualizer: AgentVisualizer,
     ) -> anyhow::Result<(Arc<Self>, TurnContext)> {
         let ConfigureSession {
             provider,
@@ -480,6 +563,7 @@ impl Session {
             active_turn: Mutex::new(None),
             services,
             next_internal_sub_id: AtomicU64::new(0),
+            visualizer: SessionVisualizer::new(visualizer, conversation_id),
         });
 
         // Dispatch the SessionConfiguredEvent first and then report any errors.
@@ -551,12 +635,82 @@ impl Session {
 
     /// Persist the event to rollout and send it to clients.
     pub(crate) async fn send_event(&self, event: Event) {
+        let event_value = match serde_json::to_value(&event) {
+            Ok(value) => value,
+            Err(err) => json!({
+                "serializationError": format!("{err:#}"),
+            }),
+        };
         // Persist the event into rollout (recorder filters as needed)
         let rollout_items = vec![RolloutItem::EventMsg(event.msg.clone())];
         self.persist_rollout_items(&rollout_items).await;
         if let Err(e) = self.tx_event.send(event).await {
             error!("failed to send tool call event: {e}");
         }
+        let state = self.visualization_state_snapshot().await;
+        self.visualizer
+            .emit(
+                "protocol_event",
+                json!({ "event": event_value }),
+                Some(state),
+            )
+            .await;
+    }
+
+    async fn visualization_state_snapshot(&self) -> Value {
+        let (history_items, token_info, rate_limits) = {
+            let state = self.state.lock().await;
+            (
+                state.history.len(),
+                state.token_info.clone(),
+                state.latest_rate_limits.clone(),
+            )
+        };
+
+        let (active_tasks, turn_state) = {
+            let active = self.active_turn.lock().await;
+            if let Some(active_turn) = active.as_ref() {
+                (
+                    active_turn
+                        .tasks
+                        .iter()
+                        .map(|(sub_id, task)| {
+                            json!({
+                                "subId": sub_id,
+                                "kind": format!("{:?}", task.kind),
+                            })
+                        })
+                        .collect::<Vec<_>>(),
+                    Some(Arc::clone(&active_turn.turn_state)),
+                )
+            } else {
+                (Vec::new(), None)
+            }
+        };
+
+        let (pending_approvals, pending_inputs) = if let Some(turn_state) = turn_state {
+            let counts = {
+                let ts = turn_state.lock().await;
+                ts.pending_counts()
+            };
+            (counts.0, counts.1)
+        } else {
+            (0, 0)
+        };
+
+        json!({
+            "activeTasks": active_tasks,
+            "pendingApprovals": pending_approvals,
+            "pendingInputs": pending_inputs,
+            "historyItems": history_items,
+            "tokenInfo": token_info,
+            "rateLimits": rate_limits,
+        })
+    }
+
+    pub(crate) async fn emit_with_state(&self, action_type: &str, action: Value) {
+        let state = self.visualization_state_snapshot().await;
+        self.visualizer.emit(action_type, action, Some(state)).await;
     }
 
     /// Emit an exec approval request event and await the user's decision.
@@ -1118,6 +1272,13 @@ impl Drop for Session {
     }
 }
 
+// The submission loop serializes user/API operations (`Op`) into the
+// single-threaded agent state machine. Instrumentation here should log the
+// incoming `sub.id`, `sub.op` discriminant, and any embedded payloads so the
+// UI can expose phase boundaries (plan → edit → test → review), task
+// lifetimes, approval wait states, and interrupts. Every high-level action
+// flows through this dispatcher before touching model state, so capturing the
+// queue depth and timestamps here provides the backbone of the visualization.
 async fn submission_loop(
     sess: Arc<Session>,
     turn_context: TurnContext,
@@ -1129,6 +1290,11 @@ async fn submission_loop(
     // To break out of this loop, send Op::Shutdown.
     while let Ok(sub) = rx_sub.recv().await {
         debug!(?sub, "Submission");
+        // Visualization hook: `sub` carries a unique id for every user prompt
+        // or control message. Emit an immediate event with `sub.id`,
+        // `std::mem::discriminant(&sub.op)`, and serialized arguments (e.g.,
+        // pending tool outputs, override knobs) so the UI can open a new
+        // timeline row before model calls, tool invocations, or approvals start.
         match sub.op {
             Op::Interrupt => {
                 sess.interrupt_task().await;
@@ -1232,6 +1398,11 @@ async fn submission_loop(
                     .client
                     .get_otel_event_manager()
                     .user_prompt(&items);
+                // Visualization hook: attempting to inject into the active
+                // task distinguishes "interruption" vs "new turn" flows. Log
+                // `sub.id`, the number of `items` injected, and whether the
+                // call to `sess.inject_input` succeeded so the UI can branch the
+                // timeline into "continue existing task" vs. "spawn RegularTask".
                 // attempt to inject input into current task
                 if let Err(items) = sess.inject_input(items).await {
                     // no current task, spawn a new one
@@ -1334,6 +1505,14 @@ async fn submission_loop(
                     // Install the new persistent context for subsequent tasks/turns.
                     turn_context = Arc::new(fresh_turn_context);
 
+                    // Visualization hook: this spawn records the beginning of a
+                    // per-turn plan/edit/test cycle using the freshly patched
+                    // TurnContext (model overrides, sandbox changes, schema,
+                    // etc.). Emit an event carrying the derived
+                    // `turn_context.client.get_model()`,
+                    // `turn_context.tools_config`, approval/sandbox policies,
+                    // and `final_output_json_schema` so the UI can open a phase
+                    // lane that reflects the effective configuration.
                     // no current task, spawn a new one with the per-turn context
                     sess.spawn_task(Arc::clone(&turn_context), sub.id, items, RegularTask)
                         .await;
@@ -1343,13 +1522,29 @@ async fn submission_loop(
                 ReviewDecision::Abort => {
                     sess.interrupt_task().await;
                 }
-                other => sess.notify_approval(&id, other).await,
+                other => {
+                    // Visualization hook: approvals unblock sandboxed commands
+                    // or apply_patch operations. Emit "approval granted"
+                    // markers that include the approval `id`, the exact
+                    // `decision`, and the elapsed wait time since the matching
+                    // approval request so the UI can show whether the task
+                    // resumed successfully afterward.
+                    sess.notify_approval(&id, other).await
+                }
             },
             Op::PatchApproval { id, decision } => match decision {
                 ReviewDecision::Abort => {
                     sess.interrupt_task().await;
                 }
-                other => sess.notify_approval(&id, other).await,
+                other => {
+                    // Visualization hook: approvals unblock sandboxed commands
+                    // or apply_patch operations. Emit "approval granted"
+                    // markers that include the approval `id`, the exact
+                    // `decision`, and the elapsed wait time since the matching
+                    // approval request so the UI can show whether the task
+                    // resumed successfully afterward.
+                    sess.notify_approval(&id, other).await
+                }
             },
             Op::AddToHistory { text } => {
                 let id = sess.conversation_id;
@@ -1434,6 +1629,11 @@ async fn submission_loop(
                     }])
                     .await
                 {
+                    // Visualization hook: compaction runs as its own task to
+                    // recover context window headroom. Emit an event that logs
+                    // the triggering token counts, `sub.id`, and the prompt
+                    // items that will be summarized so the UI can show why
+                    // tool/model calls were paused.
                     sess.spawn_task(Arc::clone(&turn_context), sub.id, items, CompactTask)
                         .await;
                 }
@@ -1496,6 +1696,11 @@ async fn submission_loop(
                 sess.send_event(event).await;
             }
             Op::Review { review_request } => {
+                // Visualization hook: Review tasks spin up a dedicated child
+                // session with isolated history. Emit an event with the
+                // `sub.id`, `review_request` metadata (target files, diffs),
+                // and parent turn identifiers so the UI can open a "review"
+                // lane and later collapse back once `ExitedReviewMode` fires.
                 spawn_review_thread(
                     sess.clone(),
                     config.clone(),
@@ -1626,6 +1831,11 @@ pub(crate) async fn run_task(
     if input.is_empty() {
         return None;
     }
+    // Visualization hook: TaskStarted kicks off a new run loop. Emit an event
+    // carrying `sub_id`, `turn_context.client.get_model()`, reasoning knobs,
+    // and the serialized `input` so downstream latency metrics (model call
+    // duration, approval wait, tool runtime) can be derived relative to this
+    // moment.
     let event = Event {
         id: sub_id.clone(),
         msg: EventMsg::TaskStarted(TaskStartedEvent {
@@ -1633,8 +1843,20 @@ pub(crate) async fn run_task(
         }),
     };
     sess.send_event(event).await;
-
+    let input_serialized = serde_json::to_value(&input).unwrap_or(Value::Null);
     let initial_input_for_turn: ResponseInputItem = ResponseInputItem::from(input);
+    sess.emit_with_state(
+        "task_started",
+        json!({
+            "subId": sub_id,
+            "model": turn_context.client.get_model(),
+            "reasoningEffort": turn_context.client.get_reasoning_effort(),
+            "reasoningSummary": turn_context.client.get_reasoning_summary(),
+            "input": input_serialized,
+            "cwd": turn_context.cwd.display().to_string(),
+        }),
+    )
+    .await;
     // For review threads, keep an isolated in-memory history so the
     // model sees a fresh conversation without the parent session's history.
     // For normal turns, continue recording to the session history as before.
@@ -1645,6 +1867,11 @@ pub(crate) async fn run_task(
         review_thread_history.extend(sess.build_initial_context(turn_context.as_ref()));
         review_thread_history.push(initial_input_for_turn.into());
     } else {
+        // Visualization hook: recording the user input updates both the in
+        // memory history and the rollout file. Emit an event with the
+        // serialized `initial_input_for_turn` (including role + content
+        // metadata) so the UI can surface "memory updated" markers tied to
+        // AGENTS.md derived prompts.
         sess.record_input_and_rollout_usermsg(&initial_input_for_turn)
             .await;
     }
@@ -1652,6 +1879,10 @@ pub(crate) async fn run_task(
     let mut last_agent_message: Option<String> = None;
     // Although from the perspective of codex.rs, TurnDiffTracker has the lifecycle of a Task which contains
     // many turns, from the perspective of the user, it is a single turn.
+    // Visualization hook: expose this tracker so the UI can present a
+    // chronological diff timeline (edit → test) alongside tool executions and
+    // final commits. Log the tracker id plus per-file diff metadata when
+    // snapshots are requested so visual diff lanes can stay in sync.
     let turn_diff_tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
     let mut auto_compact_recently_attempted = false;
 
@@ -1676,6 +1907,12 @@ pub(crate) async fn run_task(
         //   conversation history on each turn. The rollout file, however, should
         //   only record the new items that originated in this turn so that it
         //   represents an append-only log without duplicates.
+        // Visualization hook: `turn_input` represents the full prompt payload
+        // that will be sent to the LLM this turn (history, pending user input,
+        // AGENTS.md instructions, plan/test diffs). Snapshot each
+        // `ResponseItem` with its role/call_id and annotate the source (session
+        // history vs. pending_input vs. injected tool output) so the UI can
+        // reconstruct the composite prompt and diff it across turns.
         let turn_input: Vec<ResponseItem> = if is_review_mode {
             if !pending_input.is_empty() {
                 review_thread_history.extend(pending_input);
@@ -1686,6 +1923,10 @@ pub(crate) async fn run_task(
             sess.turn_input_with_history(pending_input).await
         };
 
+        // Visualization hook: `turn_input_messages` flattens assistant/user
+        // utterances so inspectors can preview the raw text that will enter the
+        // LLM. Capture these strings alongside their originating `ResponseItem`
+        // indices to power prompt previews.
         let turn_input_messages: Vec<String> = turn_input
             .iter()
             .filter_map(|item| match item {
@@ -1699,6 +1940,11 @@ pub(crate) async fn run_task(
                 })
             })
             .collect();
+        // Visualization hook: this is the tight turn loop that issues a single
+        // streaming request to the model and reacts to tool calls. Emit a
+        // "turn started" marker containing `sub_id`, the prompt hash, and
+        // `turn_input_messages` so latency/token charts can align with the raw
+        // prompt content.
         match run_turn(
             Arc::clone(&sess),
             Arc::clone(&turn_context),
@@ -1717,6 +1963,11 @@ pub(crate) async fn run_task(
                     .client
                     .get_auto_compact_token_limit()
                     .unwrap_or(i64::MAX);
+                // Visualization hook: compare `total_token_usage` with
+                // `limit` to drive a "context pressure" gauge. Emit the raw
+                // `TokenUsage` fields (prompt/output/total) plus the computed
+                // `limit` so guardrail events can explain why the agent pivoted
+                // or triggered compaction.
                 let total_usage_tokens = total_token_usage
                     .as_ref()
                     .map(TokenUsage::tokens_in_context_window);
@@ -1828,6 +2079,12 @@ pub(crate) async fn run_task(
                 }
 
                 if token_limit_reached {
+                    // Visualization hook: hitting the limit signals high
+                    // context pressure. Emit an event when we enter the
+                    // summarization loop that captures `total_usage_tokens`,
+                    // `limit`, and whether `auto_compact_recently_attempted`
+                    // was already true so the UI can plot compaction attempts
+                    // and their outcomes.
                     if auto_compact_recently_attempted {
                         let limit_str = limit.to_string();
                         let current_tokens = total_usage_tokens
@@ -1931,6 +2188,10 @@ async fn run_turn(
     sub_id: String,
     input: Vec<ResponseItem>,
 ) -> CodexResult<TurnRunResult> {
+    // Visualization hook: snapshot the MCP/tool catalog each turn so the UI
+    // can display which schemas/versions were available when a tool call was
+    // proposed. Log the tool id, schema hash/version, and connection metadata
+    // so provenance can be shown alongside tool errors.
     let mcp_tools = sess.services.mcp_connection_manager.list_all_tools();
     let router = Arc::new(ToolRouter::from_config(
         &turn_context.tools_config,
@@ -1942,6 +2203,25 @@ async fn run_turn(
         .get_model_family()
         .supports_parallel_tool_calls;
     let parallel_tool_calls = model_supports_parallel;
+    let available_tools = router
+        .specs()
+        .iter()
+        .map(|spec| spec.name().to_string())
+        .collect::<Vec<_>>();
+    sess.emit_with_state(
+        "tool_catalog_snapshot",
+        json!({
+            "subId": sub_id,
+            "tools": available_tools,
+            "parallelToolCallsEnabled": parallel_tool_calls,
+        }),
+    )
+    .await;
+    // Visualization hook: this prompt object is the exact LLM request payload
+    // (messages, tool specs, streaming flags, JSON schema). Capture the full
+    // `prompt.input` (with role/source annotations), `prompt.tools`
+    // definitions, `parallel_tool_calls`, and reasoning/sampling knobs so the
+    // browser timeline can render an "LLM request envelope".
     let prompt = Prompt {
         input,
         tools: router.specs(),
@@ -1949,8 +2229,27 @@ async fn run_turn(
         base_instructions_override: turn_context.base_instructions.clone(),
         output_schema: turn_context.final_output_json_schema.clone(),
     };
+    let prompt_input_value = serde_json::to_value(&prompt.input).unwrap_or(Value::Null);
+    let base_override = prompt.base_instructions_override.clone();
+    let output_schema = prompt.output_schema.clone();
+    sess.emit_with_state(
+        "llm_prompt_prepared",
+        json!({
+            "subId": sub_id,
+            "model": turn_context.client.get_model(),
+            "parallelToolCalls": parallel_tool_calls,
+            "input": prompt_input_value,
+            "baseInstructionsOverride": base_override,
+            "outputSchema": output_schema,
+        }),
+    )
+    .await;
 
     let mut retries = 0;
+    // Visualization hook: record retry attempts and elapsed time so latency
+    // charts can annotate disconnects, backoff windows, and retry budgets.
+    // Emit telemetry with the `retries` count, `max_retries`, error variant,
+    // and computed `delay` for each loop iteration.
     loop {
         match try_run_turn(
             Arc::clone(&router),
@@ -1962,7 +2261,20 @@ async fn run_turn(
         )
         .await
         {
-            Ok(output) => return Ok(output),
+            Ok(output) => {
+                let processed_count = output.processed_items.len();
+                let token_usage = output.total_token_usage.clone();
+                sess.emit_with_state(
+                    "llm_response_complete",
+                    json!({
+                        "subId": sub_id,
+                        "processedItemCount": processed_count,
+                        "tokenUsage": token_usage,
+                    }),
+                )
+                .await;
+                return Ok(output);
+            }
             Err(CodexErr::Interrupted) => return Err(CodexErr::Interrupted),
             Err(CodexErr::EnvVar(var)) => return Err(CodexErr::EnvVar(var)),
             Err(e @ CodexErr::Fatal(_)) => return Err(e),
@@ -1994,11 +2306,27 @@ async fn run_turn(
                     // Surface retry information to any UI/front‑end so the
                     // user understands what is happening instead of staring
                     // at a seemingly frozen screen.
+                    // Visualization hook: forward this message (including the
+                    // formatted error text, `retries`, `max_retries`, and
+                    // `delay`) to the live timeline so we can show
+                    // guardrail/latency bars for each retry attempt alongside
+                    // cumulative wall-clock time.
                     sess.notify_stream_error(
                         &sub_id,
                         format!(
                             "stream error: {e}; retrying {retries}/{max_retries} in {delay:?}…"
                         ),
+                    )
+                    .await;
+                    sess.emit_with_state(
+                        "llm_retry_scheduled",
+                        json!({
+                            "subId": sub_id,
+                            "error": format!("{e:?}"),
+                            "retries": retries,
+                            "maxRetries": max_retries,
+                            "delayMs": delay.as_millis(),
+                        }),
                     )
                     .await;
 
@@ -2090,6 +2418,11 @@ async fn try_run_turn(
         })
     };
 
+    // Visualization hook: persisting the turn context creates a durable audit
+    // trail of the agent's working directory, sandbox, and reasoning knobs.
+    // Emit a timeline event containing the serialized `TurnContextItem` so the
+    // UI can correlate context-window pressure against cwd, approval policy,
+    // sandbox policy, and reasoning settings over time.
     let rollout_item = RolloutItem::TurnContext(TurnContextItem {
         cwd: turn_context.cwd.clone(),
         approval_policy: turn_context.approval_policy,
@@ -2099,9 +2432,41 @@ async fn try_run_turn(
         summary: turn_context.client.get_reasoning_summary(),
     });
     sess.persist_rollout_items(&[rollout_item]).await;
-    let mut stream = turn_context.client.clone().stream(&prompt).await?;
+    sess.emit_with_state(
+        "turn_context_persisted",
+        json!({
+            "subId": sub_id,
+            "cwd": turn_context.cwd.display().to_string(),
+            "approvalPolicy": turn_context.approval_policy,
+            "sandboxPolicy": turn_context.sandbox_policy.clone(),
+            "model": turn_context.client.get_model(),
+            "reasoningEffort": turn_context.client.get_reasoning_effort(),
+            "reasoningSummary": turn_context.client.get_reasoning_summary(),
+        }),
+    )
+    .await;
+    // Visualization hook: this stream() call is the precise LLM request.
+    // Capture the instant it begins and include the serialized `prompt` so
+    // latency can be measured until the corresponding `ResponseEvent::Completed`
+    // arrives while showing the raw payload that was transmitted.
+    let prompt_ref = prompt.as_ref();
+    let mut stream = turn_context.client.clone().stream(prompt_ref).await?;
+    sess.emit_with_state(
+        "llm_stream_started",
+        json!({
+            "subId": sub_id,
+            "promptInputCount": prompt_ref.input.len(),
+            "toolCount": prompt_ref.tools.len(),
+            "parallelToolCalls": prompt_ref.parallel_tool_calls,
+        }),
+    )
+    .await;
 
     let mut output = Vec::new();
+    // Visualization hook: ToolCallRuntime orchestrates concurrent tool
+    // execution. Track its lifecycle by logging tool names, `call_id`s,
+    // argument payloads, stdout/stderr streams, approval waits, and retry
+    // metadata so the UI can display per-tool statuses.
     let mut tool_runtime = ToolCallRuntime::new(
         Arc::clone(&router),
         Arc::clone(&sess),
@@ -2139,6 +2504,11 @@ async fn try_run_turn(
         match event {
             ResponseEvent::Created => {}
             ResponseEvent::OutputItemDone(item) => {
+                // Visualization hook: tool call proposals surface here. Emit an
+                // event with `call.tool_name`, `call.call_id`, argument JSON,
+                // and the assigned `index` so the UI can draw per-call
+                // lifecycles (proposed → running → completed/failed) and show
+                // argument previews for debugging.
                 match ToolRouter::build_tool_call(sess.as_ref(), item.clone()) {
                     Ok(Some(call)) => {
                         let payload_preview = call.payload.log_payload().into_owned();
@@ -2212,12 +2582,20 @@ async fn try_run_turn(
             ResponseEvent::RateLimits(snapshot) => {
                 // Update internal state with latest rate limits, but defer sending until
                 // token usage is available to avoid duplicate TokenCount events.
+                // Visualization hook: stash this snapshot so the UI can render
+                // a rate-limit chart alongside token consumption per turn. Log
+                // the full `RateLimitSnapshot` (limit, remaining, reset) to
+                // drive accurate quota visualizations.
                 sess.update_rate_limits(sub_id, snapshot).await;
             }
             ResponseEvent::Completed {
                 response_id: _,
                 token_usage,
             } => {
+                // Visualization hook: Completed marks the end of the model
+                // stream. Emit an event with `token_usage`, elapsed stream
+                // duration, and accumulated diff summaries to drive usage and
+                // throughput charts.
                 sess.update_token_usage_info(sub_id, turn_context.as_ref(), token_usage.as_ref())
                     .await;
 
@@ -2247,6 +2625,10 @@ async fn try_run_turn(
                 // In review child threads, suppress assistant text deltas; the
                 // UI will show a selection popup from the final ReviewOutput.
                 if !turn_context.is_review_mode {
+                    // Visualization hook: forward streaming assistant text so
+                    // the UI can render live deltas synchronized with tool
+                    // activity and reasoning traces. Include the raw `delta`
+                    // text and offset indices for accurate playback.
                     let event = Event {
                         id: sub_id.to_string(),
                         msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent { delta }),
@@ -2257,6 +2639,9 @@ async fn try_run_turn(
                 }
             }
             ResponseEvent::ReasoningSummaryDelta(delta) => {
+                // Visualization hook: reasoning deltas power the "thought
+                // bubble" lane. Log the structured `delta` segments and their
+                // timestamps relative to tool calls to highlight cause/effect.
                 let event = Event {
                     id: sub_id.to_string(),
                     msg: EventMsg::AgentReasoningDelta(AgentReasoningDeltaEvent { delta }),
@@ -2264,6 +2649,10 @@ async fn try_run_turn(
                 sess.send_event(event).await;
             }
             ResponseEvent::ReasoningSummaryPartAdded => {
+                // Visualization hook: treat section breaks as structural cues
+                // for the reasoning timeline (e.g., plan → edit transitions).
+                // Emit the zero-argument event with a precise timestamp for
+                // segmenting the reasoning lane.
                 let event = Event {
                     id: sub_id.to_string(),
                     msg: EventMsg::AgentReasoningSectionBreak(AgentReasoningSectionBreakEvent {}),
@@ -2272,6 +2661,10 @@ async fn try_run_turn(
             }
             ResponseEvent::ReasoningContentDelta(delta) => {
                 if sess.show_raw_agent_reasoning() {
+                    // Visualization hook: raw reasoning is noisy but valuable
+                    // for power users. Surface it in a collapsible lane with
+                    // cache-hit/context-window annotations by logging the raw
+                    // `delta` chunks and any available metadata.
                     let event = Event {
                         id: sub_id.to_string(),
                         msg: EventMsg::AgentReasoningRawContentDelta(
@@ -2293,6 +2686,11 @@ async fn handle_non_tool_response_item(
 ) -> CodexResult<Option<ResponseInputItem>> {
     debug!(?item, "Output item");
 
+    // Visualization hook: non-tool items include plan/edit/test narration,
+    // approvals, and final assistant responses. Emit annotations that carry the
+    // raw `item` payload (role, text, call ids) so the UI can label timeline
+    // rows (e.g., "plan drafted", "final answer", "approval requested") and
+    // correlate them with reasoning deltas.
     match &item {
         ResponseItem::Message { .. }
         | ResponseItem::Reasoning { .. }
@@ -2780,6 +3178,7 @@ mod tests {
             active_turn: Mutex::new(None),
             services,
             next_internal_sub_id: AtomicU64::new(0),
+            visualizer: SessionVisualizer::new(AgentVisualizer::from_env(), conversation_id),
         };
         (session, turn_context)
     }
@@ -2853,6 +3252,7 @@ mod tests {
             active_turn: Mutex::new(None),
             services,
             next_internal_sub_id: AtomicU64::new(0),
+            visualizer: SessionVisualizer::new(AgentVisualizer::from_env(), conversation_id),
         });
         (session, turn_context, rx_event)
     }

--- a/codex-rs/core/src/conversation_history.rs
+++ b/codex-rs/core/src/conversation_history.rs
@@ -17,6 +17,10 @@ impl ConversationHistory {
         self.items.clone()
     }
 
+    pub(crate) fn len(&self) -> usize {
+        self.items.len()
+    }
+
     /// `items` is ordered from oldest to newest.
     pub(crate) fn record_items<I>(&mut self, items: I)
     where

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -67,6 +67,7 @@ pub mod spawn;
 pub mod terminal;
 mod tools;
 pub mod turn_diff_tracker;
+mod visualizer;
 pub use rollout::ARCHIVED_SESSIONS_SUBDIR;
 pub use rollout::INTERACTIVE_SESSION_SOURCES;
 pub use rollout::RolloutRecorder;

--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -97,6 +97,10 @@ impl TurnState {
             ret
         }
     }
+
+    pub(crate) fn pending_counts(&self) -> (usize, usize) {
+        (self.pending_approvals.len(), self.pending_input.len())
+    }
 }
 
 impl ActiveTurn {

--- a/codex-rs/core/src/visualizer.rs
+++ b/codex-rs/core/src/visualizer.rs
@@ -1,0 +1,224 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use codex_protocol::ConversationId;
+use futures::SinkExt;
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::mpsc;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use tracing::debug;
+use tracing::error;
+use tracing::warn;
+use url::Url;
+
+#[derive(Clone)]
+pub(crate) struct AgentVisualizer {
+    sender: Option<mpsc::Sender<VisualizerEvent>>,
+    sequence: Arc<AtomicU64>,
+}
+
+#[derive(Clone)]
+pub(crate) struct SessionVisualizer {
+    inner: AgentVisualizer,
+    conversation_id: ConversationId,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct VisualizerEvent {
+    pub(crate) sequence: u64,
+    pub(crate) timestamp_ms: u128,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) conversation_id: Option<ConversationId>,
+    pub(crate) action_type: String,
+    pub(crate) action: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) state: Option<Value>,
+}
+
+impl AgentVisualizer {
+    pub(crate) fn from_env() -> Self {
+        let url = std::env::var("CODEX_VISUALIZER_WS").ok();
+        Self::new(url)
+    }
+
+    pub(crate) fn new(url: Option<String>) -> Self {
+        if let Some(url) = url.and_then(Self::normalize_url) {
+            let (tx, mut rx) = mpsc::channel(256);
+            let url = Arc::new(url);
+            tokio::spawn(async move {
+                let mut pending = VecDeque::<VisualizerEvent>::new();
+                let mut backoff = Duration::from_secs(1);
+                let mut stream = None;
+
+                loop {
+                    let next_event = if let Some(event) = pending.pop_front() {
+                        Some(event)
+                    } else {
+                        rx.recv().await
+                    };
+
+                    let Some(event) = next_event else {
+                        break;
+                    };
+
+                    let stream_ref = match stream.as_mut() {
+                        Some(existing) => existing,
+                        None => match connect_async(url.as_ref()).await {
+                            Ok((ws, _)) => {
+                                backoff = Duration::from_secs(1);
+                                stream = Some(ws);
+                                stream.as_mut().expect("stream newly set")
+                            }
+                            Err(err) => {
+                                error!("failed to connect to visualizer websocket: {err:?}");
+                                pending.push_front(event);
+                                tokio::time::sleep(backoff).await;
+                                backoff = (backoff.saturating_mul(2)).min(Duration::from_secs(30));
+                                continue;
+                            }
+                        },
+                    };
+
+                    let serialized = match serde_json::to_string(&event) {
+                        Ok(payload) => payload,
+                        Err(err) => {
+                            error!("failed to serialize visualizer event: {err:?}");
+                            pending.push_front(event);
+                            continue;
+                        }
+                    };
+
+                    match stream_ref.send(Message::Text(serialized)).await {
+                        Ok(()) => {
+                            while let Ok(event) = rx.try_recv() {
+                                pending.push_back(event);
+                            }
+                        }
+                        Err(err) => {
+                            error!("failed to send visualizer event: {err:?}");
+                            pending.push_front(event);
+                            if let Some(mut ws) = stream.take() {
+                                if let Err(close_err) = ws.close(None).await {
+                                    debug!(
+                                        "failed to close visualizer websocket cleanly: {close_err:?}"
+                                    );
+                                }
+                            }
+                            tokio::time::sleep(backoff).await;
+                            backoff = (backoff.saturating_mul(2)).min(Duration::from_secs(30));
+                        }
+                    }
+                }
+
+                if let Some(mut ws) = stream {
+                    if let Err(err) = ws.close(None).await {
+                        debug!("failed to close visualizer websocket cleanly: {err:?}");
+                    }
+                }
+
+                debug!("visualizer channel closed; stopping websocket forwarder");
+            });
+
+            Self {
+                sender: Some(tx),
+                sequence: Arc::new(AtomicU64::new(0)),
+            }
+        } else {
+            Self {
+                sender: None,
+                sequence: Arc::new(AtomicU64::new(0)),
+            }
+        }
+    }
+
+    fn normalize_url(raw: String) -> Option<String> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        let mut attempts = Vec::from([trimmed.to_string()]);
+        if !trimmed.contains("://") {
+            attempts.push(format!("ws://{trimmed}"));
+        }
+
+        for candidate in attempts {
+            match Url::parse(&candidate) {
+                Ok(mut parsed) => {
+                    let has_role = parsed.query_pairs().any(|(key, _)| key == "role");
+                    if !has_role {
+                        parsed.query_pairs_mut().append_pair("role", "producer");
+                    }
+                    return Some(parsed.into());
+                }
+                Err(err) => {
+                    warn!("invalid visualizer websocket url '{candidate}': {err:#}");
+                }
+            }
+        }
+
+        warn!("falling back to raw CODEX_VISUALIZER_WS value without validation");
+        Some(trimmed.to_string())
+    }
+
+    pub(crate) async fn emit(
+        &self,
+        conversation_id: Option<ConversationId>,
+        action_type: impl Into<String>,
+        action: Value,
+        state: Option<Value>,
+    ) {
+        if let Some(tx) = &self.sender {
+            let timestamp_ms = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_else(|_| Duration::from_secs(0))
+                .as_millis();
+            let sequence = self.sequence.fetch_add(1, Ordering::SeqCst);
+            let event = VisualizerEvent {
+                sequence,
+                timestamp_ms,
+                conversation_id,
+                action_type: action_type.into(),
+                action,
+                state,
+            };
+            if tx.send(event).await.is_err() {
+                debug!("visualizer channel dropped; disabling event stream");
+            }
+        }
+    }
+}
+
+impl Default for AgentVisualizer {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+impl SessionVisualizer {
+    pub(crate) fn new(inner: AgentVisualizer, conversation_id: ConversationId) -> Self {
+        Self {
+            inner,
+            conversation_id,
+        }
+    }
+
+    pub(crate) async fn emit(
+        &self,
+        action_type: impl Into<String>,
+        action: Value,
+        state: Option<Value>,
+    ) {
+        self.inner
+            .emit(Some(self.conversation_id), action_type, action, state)
+            .await;
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,37 @@ importers:
         specifier: ^3.24.6
         version: 3.24.6(zod@3.25.76)
 
+  visualizer/server:
+    dependencies:
+      ws:
+        specifier: ^8.17.0
+        version: 8.18.3
+
+  visualizer/web:
+    dependencies:
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.4
+        version: 18.3.25
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.25)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.1
+        version: 4.7.0(vite@5.4.20(@types/node@20.19.18))
+      typescript:
+        specifier: ^5.6.2
+        version: 5.9.2
+      vite:
+        specifier: ^5.2.0
+        version: 5.4.20(@types/node@20.19.18)
+
 packages:
 
   '@babel/code-frame@7.27.1':
@@ -220,6 +251,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
@@ -239,16 +282,34 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.10':
     resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.10':
     resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.10':
@@ -257,16 +318,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.10':
     resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.10':
     resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.10':
@@ -275,10 +354,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.10':
     resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.10':
@@ -287,10 +378,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.10':
     resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.10':
@@ -299,10 +402,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.10':
     resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.10':
@@ -311,10 +426,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.10':
     resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.10':
@@ -323,16 +450,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.10':
     resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.10':
     resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.10':
@@ -347,6 +492,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.10':
     resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
     engines: {node: '>=18'}
@@ -357,6 +508,12 @@ packages:
     resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.10':
@@ -371,11 +528,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.10':
     resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.10':
     resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
@@ -383,10 +552,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.10':
     resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.10':
@@ -562,6 +743,9 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
   '@rollup/rollup-android-arm-eabi@4.52.3':
     resolution: {integrity: sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==}
     cpu: [arm]
@@ -729,6 +913,17 @@ packages:
   '@types/node@20.19.18':
     resolution: {integrity: sha512-KeYVbfnbsBCyKG8e3gmUqAfyZNcoj/qpEbHRkQkfZdKOBrU7QQ+BsTdfqLSWX9/m1ytYreMhpKvp+EZi3UFYAg==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.25':
+    resolution: {integrity: sha512-oSVZmGtDPmRZtVDqvdKUi/qgCsWp5IDY29wp8na8Bj4B3cc99hfNzvNhlMkVVxctkAOGUA3Km7MMpBHAnWfcIA==}
+
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
@@ -796,6 +991,12 @@ packages:
   '@typescript-eslint/visitor-keys@8.45.0':
     resolution: {integrity: sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1002,6 +1203,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1056,6 +1260,11 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.25.10:
     resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
@@ -1587,6 +1796,10 @@ packages:
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -1813,8 +2026,21 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -1856,6 +2082,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
@@ -2117,6 +2346,37 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  vite@5.4.20:
+    resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -2152,6 +2412,18 @@ packages:
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2355,6 +2627,16 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -2384,52 +2666,103 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.10':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.10':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.10':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.10':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.10':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.10':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.10':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.10':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.10':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.10':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.10':
@@ -2438,10 +2771,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.10':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.10':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.10':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.10':
@@ -2450,13 +2789,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.10':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.10':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.10':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.10':
@@ -2737,6 +3088,8 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
   '@rollup/rollup-android-arm-eabi@4.52.3':
     optional: true
 
@@ -2869,6 +3222,17 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.25)':
+    dependencies:
+      '@types/react': 18.3.25
+
+  '@types/react@18.3.25':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.1.3
+
   '@types/stack-utils@2.0.3': {}
 
   '@types/yargs-parser@21.0.3': {}
@@ -2969,6 +3333,18 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.45.0
       eslint-visitor-keys: 4.2.1
+
+  '@vitejs/plugin-react@4.7.0(vite@5.4.20(@types/node@20.19.18))':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.4)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 5.4.20(@types/node@20.19.18)
+    transitivePeerDependencies:
+      - supports-color
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -3187,6 +3563,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  csstype@3.1.3: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -3216,6 +3594,32 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.10:
     optionalDependencies:
@@ -3949,6 +4353,10 @@ snapshots:
 
   lodash.sortby@4.7.0: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
@@ -4007,8 +4415,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11:
-    optional: true
+  nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
 
@@ -4119,7 +4526,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    optional: true
 
   prelude-ls@1.2.1: {}
 
@@ -4144,7 +4550,19 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
   react-is@18.3.1: {}
+
+  react-refresh@0.17.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   readdirp@4.1.2: {}
 
@@ -4200,6 +4618,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
   semver@7.7.2: {}
 
   shebang-command@2.0.0:
@@ -4216,8 +4638,7 @@ snapshots:
 
   slash@3.0.0: {}
 
-  source-map-js@1.2.1:
-    optional: true
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.13:
     dependencies:
@@ -4445,6 +4866,15 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+  vite@5.4.20(@types/node@20.19.18):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.52.3
+    optionalDependencies:
+      '@types/node': 20.19.18
+      fsevents: 2.3.3
+
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
@@ -4483,6 +4913,8 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+
+  ws@8.18.3: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 packages:
   - docs
   - sdk/typescript
+  - visualizer/server
+  - visualizer/web
 
 ignoredBuiltDependencies:
   - esbuild

--- a/visualizer/server/package.json
+++ b/visualizer/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@codex/visualizer-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node ./src/index.js"
+  },
+  "dependencies": {
+    "ws": "^8.17.0"
+  }
+}

--- a/visualizer/server/src/index.js
+++ b/visualizer/server/src/index.js
@@ -1,0 +1,75 @@
+import { createServer } from "node:http";
+import { WebSocketServer } from "ws";
+
+const port = Number(process.env.CODEX_VISUALIZER_PORT ?? 4100);
+const backlogLimit = Number(process.env.CODEX_VISUALIZER_BACKLOG ?? 200);
+
+const server = createServer();
+const wss = new WebSocketServer({ server });
+
+const producerSockets = new Set();
+const viewerSockets = new Set();
+const backlog = [];
+
+function broadcast(message, except) {
+  for (const socket of viewerSockets) {
+    if (socket.readyState === socket.OPEN && socket !== except) {
+      try {
+        socket.send(message);
+      } catch (err) {
+        console.warn("failed to deliver message to viewer", err);
+      }
+    }
+  }
+}
+
+function pushBacklog(message) {
+  backlog.push(message);
+  if (backlog.length > backlogLimit) {
+    backlog.splice(0, backlog.length - backlogLimit);
+  }
+}
+
+wss.on("connection", (socket, request) => {
+  const url = new URL(request?.url ?? "/", "http://localhost");
+  const role = url.searchParams.get("role") ?? "viewer";
+  const clientDescription = `${request.socket.remoteAddress ?? "unknown"}:${request.socket.remotePort ?? "?"}`;
+
+  if (role === "producer") {
+    producerSockets.add(socket);
+    console.log(`visualizer producer connected (${clientDescription})`);
+  } else {
+    viewerSockets.add(socket);
+    console.log(`visualizer viewer connected (${clientDescription})`);
+    for (const message of backlog) {
+      try {
+        socket.send(message);
+      } catch (err) {
+        console.warn("failed to replay backlog to viewer", err);
+        break;
+      }
+    }
+  }
+
+  socket.on("message", (data) => {
+    const payload = typeof data === "string" ? data : data.toString();
+    if (role === "producer") {
+      pushBacklog(payload);
+      broadcast(payload, null);
+    }
+  });
+
+  socket.on("close", () => {
+    producerSockets.delete(socket);
+    viewerSockets.delete(socket);
+    console.log(`visualizer client disconnected (${clientDescription})`);
+  });
+
+  socket.on("error", (err) => {
+    console.warn(`visualizer websocket error (${clientDescription})`, err);
+  });
+});
+
+server.listen(port, "0.0.0.0", () => {
+  console.log(`codex visualizer websocket server listening on ws://localhost:${port}`);
+});

--- a/visualizer/web/index.html
+++ b/visualizer/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codex Agent Visualizer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/visualizer/web/package.json
+++ b/visualizer/web/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@codex/visualizer-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.4",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.6.2",
+    "vite": "^5.2.0"
+  }
+}

--- a/visualizer/web/src/App.css
+++ b/visualizer/web/src/App.css
@@ -1,0 +1,129 @@
+:root {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #0f172a;
+  background-color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  background-color: inherit;
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  padding: 1.25rem 2rem;
+  background: #111827;
+  color: #f9fafb;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.header h1 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.status {
+  font-size: 0.875rem;
+  opacity: 0.85;
+}
+
+.timeline {
+  flex: 1;
+  padding: 1.5rem 2rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.event-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  background: #ffffff;
+}
+
+.event-action {
+  border-left: 4px solid #1f2937;
+  padding-left: 1rem;
+}
+
+.event-action h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.event-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.8125rem;
+  color: #475569;
+  margin-bottom: 0.5rem;
+}
+
+.event-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.event-json {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+  line-height: 1.35;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  overflow-x: auto;
+  white-space: pre-wrap;
+}
+
+.event-state {
+  background: #f8fafc;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #cbd5f5;
+}
+
+.state-json {
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.85rem;
+  line-height: 1.35;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  background: #ffffff;
+  color: #0f172a;
+  border: 1px solid #dbeafe;
+  overflow-x: auto;
+  white-space: pre-wrap;
+}
+
+.empty-state {
+  margin: 4rem auto;
+  text-align: center;
+  color: #475569;
+  max-width: 420px;
+}
+
+.empty-state h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.empty-state p {
+  font-size: 0.95rem;
+  line-height: 1.5;
+}

--- a/visualizer/web/src/App.tsx
+++ b/visualizer/web/src/App.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useState } from "react";
+import { actionBackground, colorForAction, stateBackground } from "./theme";
+
+type VisualizerEvent = {
+  sequence: number;
+  timestampMs: number;
+  conversationId?: string;
+  actionType: string;
+  action: unknown;
+  state?: unknown;
+};
+
+const WEBSOCKET_URL = import.meta.env.VITE_VISUALIZER_WS ?? "ws://localhost:4100/?role=viewer";
+
+function formatTimestamp(timestampMs: number) {
+  const date = new Date(timestampMs);
+  return `${date.toLocaleTimeString()} • ${date.toLocaleDateString()}`;
+}
+
+function stringify(value: unknown) {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export default function App() {
+  const [events, setEvents] = useState<VisualizerEvent[]>([]);
+  const [connectionStatus, setConnectionStatus] = useState("connecting");
+
+  useEffect(() => {
+    let socket: WebSocket | null = null;
+    let shouldReconnect = true;
+
+    const connect = () => {
+      setConnectionStatus("connecting");
+      socket = new WebSocket(WEBSOCKET_URL);
+
+      socket.onopen = () => {
+        setConnectionStatus("connected");
+      };
+
+      socket.onmessage = (event) => {
+        try {
+          const parsed = JSON.parse(event.data as string) as VisualizerEvent;
+          setEvents((prev) => {
+            const next = [...prev, parsed];
+            return next.slice(-500);
+          });
+        } catch (err) {
+          console.warn("failed to parse visualizer event", err);
+        }
+      };
+
+      socket.onclose = () => {
+        if (!shouldReconnect) {
+          return;
+        }
+        setConnectionStatus("reconnecting");
+        setTimeout(connect, 1000);
+      };
+
+      socket.onerror = (err) => {
+        console.warn("visualizer websocket error", err);
+        setConnectionStatus("error");
+      };
+    };
+
+    connect();
+
+    return () => {
+      shouldReconnect = false;
+      if (socket && socket.readyState === WebSocket.OPEN) {
+        socket.close();
+      }
+    };
+  }, []);
+
+  const orderedEvents = useMemo(
+    () => [...events].sort((a, b) => a.sequence - b.sequence),
+    [events]
+  );
+
+  return (
+    <div className="app">
+      <header className="header">
+        <h1>Codex Agent Visualizer</h1>
+        <div className="status">WebSocket status: {connectionStatus}</div>
+      </header>
+      <main className="timeline">
+        {orderedEvents.length === 0 ? (
+          <div className="empty-state">
+            <h2>No events yet</h2>
+            <p>
+              Start the Codex agent with the CODEX_VISUALIZER_WS environment variable pointing at the
+              websocket server to watch internal actions stream in real time.
+            </p>
+          </div>
+        ) : (
+          orderedEvents.map((event) => {
+            const color = colorForAction(event.actionType);
+            return (
+              <div className="event-row" key={`${event.sequence}-${event.timestampMs}`}>
+                <section
+                  className="event-action"
+                  style={{ borderLeftColor: color, background: actionBackground }}
+                >
+                  <h2>{event.actionType}</h2>
+                  <div className="event-meta">
+                    <span>#{event.sequence}</span>
+                    <span>{formatTimestamp(event.timestampMs)}</span>
+                    {event.conversationId ? <span>Conversation: {event.conversationId}</span> : null}
+                  </div>
+                  <pre className="event-json">{stringify(event.action)}</pre>
+                </section>
+                <section className="event-state" style={{ background: stateBackground }}>
+                  <h2>State after action</h2>
+                  <pre className="state-json">{stringify(event.state ?? {})}</pre>
+                </section>
+              </div>
+            );
+          })
+        )}
+      </main>
+    </div>
+  );
+}

--- a/visualizer/web/src/main.tsx
+++ b/visualizer/web/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./App.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/visualizer/web/src/theme.ts
+++ b/visualizer/web/src/theme.ts
@@ -1,0 +1,23 @@
+export const actionColors: Record<string, string> = {
+  memory_bootstrap: "#2563eb",
+  session_loop_started: "#7c3aed",
+  protocol_event: "#334155",
+  task_spawned: "#16a34a",
+  task_completed: "#0ea5e9",
+  task_aborted: "#f97316",
+  task_started: "#0f766e",
+  tool_catalog_snapshot: "#4f46e5",
+  llm_prompt_prepared: "#2563eb",
+  llm_stream_started: "#f59e0b",
+  llm_response_complete: "#14b8a6",
+  llm_retry_scheduled: "#ef4444",
+  turn_context_persisted: "#8b5cf6"
+};
+
+export const defaultActionColor = "#1f2937";
+export const stateBackground = "#f8fafc";
+export const actionBackground = "#ffffff";
+
+export function colorForAction(actionType: string): string {
+  return actionColors[actionType] ?? defaultActionColor;
+}

--- a/visualizer/web/tsconfig.json
+++ b/visualizer/web/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowJs": false,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "resolveJsonModule": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/visualizer/web/vite.config.ts
+++ b/visualizer/web/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 4173,
+    host: "0.0.0.0"
+  },
+  preview: {
+    port: 4174,
+    host: "0.0.0.0"
+  }
+});


### PR DESCRIPTION
## Summary
- keep the agent visualizer client online with a persistent websocket connection, exponential backoff, and clean shutdowns
- normalize `CODEX_VISUALIZER_WS` so producers default to `role=producer` and tolerate missing schemes
- add the `url` workspace dependency for the visualizer client

## Testing
- just fmt
- cargo check -p codex-core -q

------
https://chatgpt.com/codex/tasks/task_e_68e397c6c42c832c883a63b177788ba8